### PR TITLE
Fix carbonyl logo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,12 +3,10 @@
     <tr>
       <td>
         <p></p>
-        <pre>
-   O    O
-    \  /
-O —— Cr —— O
-    /  \
-   O    O</pre>
+        <pre>    O
+ ┌  ǁ  ┐
+─┼─ C ─┼─
+ └     ┘</pre>
       </td>
       <td><h1>Carbonyl</h1></td>
     </tr>


### PR DESCRIPTION
The existing ASCII art does not represent a carbonyl group, but instead some strange combination of chromium and oxygen. This PR fixes that by replacing it with an actual carbonyl.