### PR TITLE
fix(build): allow working directories that contain spaces

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- $(pwd))
+export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- "$(pwd)")
 
 source "$CARBONYL_ROOT/scripts/env.sh"
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- $(pwd))
+export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- "$(pwd)")
 
 source "$CARBONYL_ROOT/scripts/env.sh"
 

--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- $(pwd))
+export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- "$(pwd)")
 
 source "$CARBONYL_ROOT/scripts/env.sh"
 

--- a/scripts/gclient.sh
+++ b/scripts/gclient.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- $(pwd))
+export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- "$(pwd)")
 
 source "$CARBONYL_ROOT/scripts/env.sh"
 

--- a/scripts/gn.sh
+++ b/scripts/gn.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- $(pwd))
+export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- "$(pwd)")
 
 source "$CARBONYL_ROOT/scripts/env.sh"
 

--- a/scripts/patches.sh
+++ b/scripts/patches.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- $(pwd))
+export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- "$(pwd)")
 
 source "$CARBONYL_ROOT/scripts/env.sh"
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- $(pwd))
+export CARBONYL_ROOT=$(cd $(dirname -- "$0") && dirname -- "$(pwd)")
 
 source "$CARBONYL_ROOT/scripts/env.sh"
 


### PR DESCRIPTION
Previously, if your working directory contained an ascii space character, the `dirname` invocation would read it as multiple arguments. This breaks the `CARBONYL_ROOT` environment variable used in all build scripts.

To fix this, we just need to add quotes around the `$(pwd)` to ensure bash will parse the command correctly.
