### PR TITLE
fix(build): do not use tags for checkout

### DIFF
--- a/scripts/patches.sh
+++ b/scripts/patches.sh
@@ -6,7 +6,7 @@ source "$CARBONYL_ROOT/scripts/env.sh"
 
 cd "$CHROMIUM_SRC"
 
-chromium_upstream="111.0.5511.1"
+chromium_upstream="92da8189788b1b373cbd3348f73d695dfdc521b6"
 skia_upstream="486deb23bc2a4d3d09c66fef52c2ad64d8b4f761"
 
 if [[ "$1" == "apply" ]]; then


### PR DESCRIPTION
When chromium source is fetched with extra params `--no-history`, there will be no tag info in the local `.git` repository, and `./scripts/pacthes.sh apply` will fail because `git push --set-upstream origin fix-for-patches` fails, so use the commit hash instead.
