### PR TITLE
fix: do not checkout nacl

### DIFF
--- a/chromium/.gclient
+++ b/chromium/.gclient
@@ -7,6 +7,7 @@ solutions = [
     "custom_vars": {
       "use_rust": True,
       "checkout_pgo_profiles": True, 
+      "checkout_nacl": False,
     }
   },
 ]


### PR DESCRIPTION
NaCl is disabled in carbonyl, but its toolchain will be checked out by default. These files will occupy lots of disk space but are actually useless.