### PR TITLE
chore: fix typos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Lynx is the original terminal web browser, and the oldest one still maintained.
 
 -   Does not support a lot of modern web standards
 -   Cannot run JavaScript/WebAssembly
--   Cannot view or play medias (audio, video, DOOM)
+-   Cannot view or play media (audio, video, DOOM)
 
 ### Browsh
 

--- a/src/browser/bridge.cc
+++ b/src/browser/bridge.cc
@@ -72,7 +72,7 @@ void Renderer::DrawText(const std::string& text, const gfx::RectF& bounds, uint3
     carbonyl_renderer_draw_text(ptr_, text.c_str(), &rect, &color);
 }
 
-void Renderer::DrawBackgrond(const unsigned char* pixels, size_t pixels_size, const gfx::Rect& bounds) {
+void Renderer::DrawBackground(const unsigned char* pixels, size_t pixels_size, const gfx::Rect& bounds) {
     struct carbonyl_bridge_rect rect;
 
     rect.origin.x = bounds.x();

--- a/src/browser/bridge.h
+++ b/src/browser/bridge.h
@@ -50,7 +50,7 @@ public:
     void SetTitle(const std::string& title);
     void ClearText();
     void DrawText(const std::string& text, const gfx::RectF& bounds, uint32_t color);
-    void DrawBackgrond(const unsigned char* pixels, size_t pixels_size, const gfx::Rect& bounds);
+    void DrawBackground(const unsigned char* pixels, size_t pixels_size, const gfx::Rect& bounds);
 
 private:
     Renderer(struct carbonyl_renderer* ptr);

--- a/src/browser/host_display_client.cc
+++ b/src/browser/host_display_client.cc
@@ -34,7 +34,7 @@ void LayeredWindowUpdater::OnAllocatedSharedMemory(
 
 void LayeredWindowUpdater::Draw(const gfx::Rect& damage_rect,
                                 DrawCallback draw_callback) {
-  Renderer::Main()->DrawBackgrond(
+  Renderer::Main()->DrawBackground(
     shm_mapping_.GetMemoryAs<uint8_t>(),
     shm_mapping_.size(),
     damage_rect

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -38,7 +38,7 @@ impl Mouse {
             (_, None, _) => self.col = num,
             (_, _, None) => self.row = num,
             _ => {
-                log::warning!("Misformed mouse sequence");
+                log::warning!("Malformed mouse sequence");
 
                 return None;
             }


### PR DESCRIPTION
Found via `typos --format brief`