### PR TITLE
docs(readme): add `--rm` to Docker example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Carbonyl originally started as [`html2svg`](https://github.com/fathyb/html2svg) 
 ### Docker
 
 ```shell
-$ docker run -ti fathyb/carbonyl https://youtube.com
+$ docker run --rm -ti fathyb/carbonyl https://youtube.com
 ```
 
 ### npm


### PR DESCRIPTION
there's no need to keep the used container around.

ideally one could persist the used data paths, i.e profile data.

```
-v $(pwd)/state/config:/root/.config -v $(pwd)/state/cache:/root/.cache
```

but I haven't investigated so far what paths need to persist between runs.