### PR TITLE
docs(changelog): fix commit_preprocessors url

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,40 +10,40 @@ All notable changes to this project will be documented in this file.
 - Linux support
 - Xterm title
 - Hide stderr unless crash
-- Add `--debug` to print stderr on exit ([#23](https://github.com/orhun/git-cliff/issues/23))
-- Add navigation UI ([#86](https://github.com/orhun/git-cliff/issues/86))
-- Handle terminal resize ([#87](https://github.com/orhun/git-cliff/issues/87))
+- Add `--debug` to print stderr on exit ([#23](https://github.com/fathyb/carbonyl/issues/23))
+- Add navigation UI ([#86](https://github.com/fathyb/carbonyl/issues/86))
+- Handle terminal resize ([#87](https://github.com/fathyb/carbonyl/issues/87))
 
 ### 🐛 Bug Fixes
 
 - Parser fixes
 - Properly enter tab and return keys
-- Fix some special characters ([#35](https://github.com/orhun/git-cliff/issues/35))
-- Improve terminal size detection ([#36](https://github.com/orhun/git-cliff/issues/36))
-- Allow working directories that contain spaces ([#63](https://github.com/orhun/git-cliff/issues/63))
-- Do not use tags for checkout ([#64](https://github.com/orhun/git-cliff/issues/64))
-- Do not checkout nacl ([#79](https://github.com/orhun/git-cliff/issues/79))
-- Wrap zip files in carbonyl folder ([#88](https://github.com/orhun/git-cliff/issues/88))
-- Fix WebGL support on Linux ([#90](https://github.com/orhun/git-cliff/issues/90))
-- Fix initial freeze on Docker ([#91](https://github.com/orhun/git-cliff/issues/91))
+- Fix some special characters ([#35](https://github.com/fathyb/carbonyl/issues/35))
+- Improve terminal size detection ([#36](https://github.com/fathyb/carbonyl/issues/36))
+- Allow working directories that contain spaces ([#63](https://github.com/fathyb/carbonyl/issues/63))
+- Do not use tags for checkout ([#64](https://github.com/fathyb/carbonyl/issues/64))
+- Do not checkout nacl ([#79](https://github.com/fathyb/carbonyl/issues/79))
+- Wrap zip files in carbonyl folder ([#88](https://github.com/fathyb/carbonyl/issues/88))
+- Fix WebGL support on Linux ([#90](https://github.com/fathyb/carbonyl/issues/90))
+- Fix initial freeze on Docker ([#91](https://github.com/fathyb/carbonyl/issues/91))
 
 ### 📖 Documentation
 
 - Upload demo videos
 - Fix video layout
-- Fix a typo ([#1](https://github.com/orhun/git-cliff/issues/1))
-- Fix a typo `ie.` -> `i.e.` ([#9](https://github.com/orhun/git-cliff/issues/9))
-- Fix build instructions ([#15](https://github.com/orhun/git-cliff/issues/15))
+- Fix a typo ([#1](https://github.com/fathyb/carbonyl/issues/1))
+- Fix a typo `ie.` -> `i.e.` ([#9](https://github.com/fathyb/carbonyl/issues/9))
+- Fix build instructions ([#15](https://github.com/fathyb/carbonyl/issues/15))
 - Add ascii logo
-- Add comparisons ([#34](https://github.com/orhun/git-cliff/issues/34))
-- Add OS support ([#50](https://github.com/orhun/git-cliff/issues/50))
+- Add comparisons ([#34](https://github.com/fathyb/carbonyl/issues/34))
+- Add OS support ([#50](https://github.com/fathyb/carbonyl/issues/50))
 - Add download link
 - Fix linux download links
 - Document shared library
-- Fix a typo (`know` -> `known`) ([#71](https://github.com/orhun/git-cliff/issues/71))
+- Fix a typo (`know` -> `known`) ([#71](https://github.com/fathyb/carbonyl/issues/71))
 - Add license
 
 ### Build
 
-- Various build system fixes ([#20](https://github.com/orhun/git-cliff/issues/20))
+- Various build system fixes ([#20](https://github.com/fathyb/carbonyl/issues/20))
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,7 +25,7 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_preprocessors = [
-    { pattern = "#([0-9]+)", replace = "[#${1}](https://github.com/orhun/git-cliff/issues/${1})" }
+    { pattern = "#([0-9]+)", replace = "[#${1}](https://github.com/fathyb/carbonyl/issues/${1})" }
 ]
 commit_parsers = [
     { message = "^feat", group = "<!-- 0 -->🚀 Features" },


### PR DESCRIPTION
Looks like git-cliff was generating links to the git-cliff repo.