### PR TITLE
feat(macos): use Cmd instead of Alt for navigation shortcuts

### DIFF
--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -1,42 +1,67 @@
 use crate::control_flow;
 
-use super::{Event, Key, ParseControlFlow};
+use super::{Event, ParseControlFlow};
+
+pub struct Keyboard {
+    state: State,
+}
+
+#[derive(Clone, Debug)]
+pub struct Key {
+    pub char: u8,
+    pub modifiers: KeyModifiers,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct KeyModifiers {
+    pub alt: bool,
+    pub meta: bool,
+    pub shift: bool,
+    pub control: bool,
+}
 
 enum State {
     Separator,
-    Modifier,
-    Key,
-}
-
-pub struct Keyboard {
-    alt: bool,
-    state: State,
+    Modifier(u8),
 }
 
 impl Keyboard {
     pub fn new() -> Self {
         Self {
-            alt: false,
             state: State::Separator,
         }
     }
-    pub fn key(key: u8, alt: bool) -> Option<Event> {
+    pub fn key(key: u8, modifiers: u8) -> Option<Event> {
+        let modifiers = KeyModifiers::parse(modifiers);
+
         match key {
             // Up
             b'A' => Some(Event::KeyPress {
-                key: Key { char: 0x11, alt },
+                key: Key {
+                    char: 0x11,
+                    modifiers,
+                },
             }),
             // Down
             b'B' => Some(Event::KeyPress {
-                key: Key { char: 0x12, alt },
+                key: Key {
+                    char: 0x12,
+                    modifiers,
+                },
             }),
             // Right
             b'C' => Some(Event::KeyPress {
-                key: Key { char: 0x13, alt },
+                key: Key {
+                    char: 0x13,
+                    modifiers,
+                },
             }),
             // Left
             b'D' => Some(Event::KeyPress {
-                key: Key { char: 0x14, alt },
+                key: Key {
+                    char: 0x14,
+                    modifiers,
+                },
             }),
             _ => None,
         }
@@ -45,19 +70,55 @@ impl Keyboard {
     pub fn parse(&mut self, key: u8) -> ParseControlFlow {
         self.state = match self.state {
             State::Separator => match key {
-                b';' => State::Modifier,
+                b';' => State::Modifier(0),
                 _ => control_flow!(break)?,
             },
-            State::Modifier => {
-                if key == b'3' {
-                    self.alt = true;
-                }
-
-                State::Key
-            }
-            State::Key => control_flow!(break Self::key(key, self.alt))?,
+            State::Modifier(code) => match key {
+                b'0'..=b'9' => State::Modifier(code * 10 + key - b'0'),
+                key => control_flow!(break Self::key(key, code))?,
+            },
         };
 
         control_flow!(continue)
+    }
+}
+
+impl From<u8> for Key {
+    fn from(char: u8) -> Self {
+        Self {
+            char,
+            modifiers: KeyModifiers::default(),
+        }
+    }
+}
+
+impl KeyModifiers {
+    pub fn parse(key: u8) -> Self {
+        let (alt, meta, shift, control) = (0b1000, 0b0100, 0b0010, 0b0001);
+        let mask = match key {
+            2 => shift,
+            3 => alt,
+            4 => shift | alt,
+            5 => control,
+            6 => shift | control,
+            7 => alt | control,
+            8 => shift | alt | control,
+            9 => meta,
+            10 => meta | shift,
+            11 => meta | alt,
+            12 => meta | alt | shift,
+            13 => meta | control,
+            14 => meta | control | shift,
+            15 => meta | control | alt,
+            16 => meta | control | alt | shift,
+            _ => 0,
+        };
+
+        KeyModifiers {
+            alt: alt & mask != 0,
+            meta: meta & mask != 0,
+            shift: shift & mask != 0,
+            control: control & mask != 0,
+        }
     }
 }

--- a/src/input/parser.rs
+++ b/src/input/parser.rs
@@ -26,18 +26,6 @@ pub enum TerminalEvent {
 }
 
 #[derive(Clone, Debug)]
-pub struct Key {
-    pub char: u8,
-    pub alt: bool,
-}
-
-impl From<u8> for Key {
-    fn from(char: u8) -> Self {
-        Self { char, alt: false }
-    }
-}
-
-#[derive(Clone, Debug)]
 pub enum Event {
     KeyPress { key: Key },
     MouseUp { row: usize, col: usize },
@@ -104,7 +92,7 @@ impl Parser {
                 Sequence::Control => match key {
                     b'<' => Sequence::Mouse(Mouse::new()),
                     b'1' => Sequence::Keyboard(Keyboard::new()),
-                    key => emit!(Keyboard::key(key, false)),
+                    key => emit!(Keyboard::key(key, 0)),
                 },
                 Sequence::Mouse(ref mut mouse) => parse!(mouse, key),
                 Sequence::Keyboard(ref mut keyboard) => parse!(keyboard, key),

--- a/src/ui/navigation.rs
+++ b/src/ui/navigation.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
@@ -46,8 +48,13 @@ impl Navigation {
     }
 
     pub fn keypress(&mut self, key: &Key) -> NavigationAction {
+        let modifier_key = match env::consts::OS {
+            "macos" => key.modifiers.meta,
+            _ => key.modifiers.alt,
+        };
+
         match self.cursor {
-            None => match (key.alt, key.char) {
+            None => match (modifier_key, key.char) {
                 (true, 0x14) => NavigationAction::GoBack(),
                 (true, 0x13) => NavigationAction::GoForward(),
                 _ => NavigationAction::Forward,


### PR DESCRIPTION
Fixes #98