### PR TITLE
fix(build): link to Chromium sysroot libs on Linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,4 +3,6 @@ fn main() {
     println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/usr/lib/x86_64-linux-gnu");
     println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/usr");
     println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot");
+
+    println!("cargo:rustc-link-arg=--sysroot=./chromium/src/build/linux/debian_bullseye_amd64-sysroot");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,28 @@
-fn main() {
+#[cfg(target_arch = "x86_64")]
+fn link_sysroot() {
     println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/lib/x86_64-linux-gnu");
     println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/usr/lib/x86_64-linux-gnu");
-    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/usr");
-    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot");
 
-    println!("cargo:rustc-link-arg=--sysroot=./chromium/src/build/linux/debian_bullseye_amd64-sysroot");
+    println!(
+        "cargo:rustc-link-arg=--sysroot=./chromium/src/build/linux/debian_bullseye_amd64-sysroot"
+    );
+}
+
+#[cfg(target_arch = "x86")]
+fn link_sysroot() {
+    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_i386-sysroot/lib/i386-linux-gnu");
+    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_i386-sysroot/usr/lib/i386-linux-gnu");
+
+    println!(
+        "cargo:rustc-link-arg=--sysroot=./chromium/src/build/linux/debian_bullseye_i386-sysroot"
+    );
+}
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+fn link_sysroot() {
+    // Intentionally left blank.
+}
+
+fn main() {
+    link_sysroot();
 }

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,37 @@
+use std::path::PathBuf;
+
 #[cfg(target_arch = "x86_64")]
 fn link_sysroot() {
-    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/lib/x86_64-linux-gnu");
-    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/usr/lib/x86_64-linux-gnu");
+    let sysroot_path = PathBuf::from("./chromium/src/build/linux/debian_bullseye_amd64-sysroot");
 
-    println!(
-        "cargo:rustc-link-arg=--sysroot=./chromium/src/build/linux/debian_bullseye_amd64-sysroot"
-    );
+    if sysroot_path.is_dir() {
+        println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/lib/x86_64-linux-gnu");
+        println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/usr/lib/x86_64-linux-gnu");
+
+        println!(
+            "cargo:rustc-link-arg=--sysroot=./chromium/src/build/linux/debian_bullseye_amd64-sysroot"
+        );
+    } else {
+        println!("cargo:warning={}", "x86_64 debian sysroot provided by chromium was not found!");
+        println!("cargo:warning={}", "carbonyl may fail to link against a proper libc!");
+    }
 }
 
 #[cfg(target_arch = "x86")]
 fn link_sysroot() {
-    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_i386-sysroot/lib/i386-linux-gnu");
-    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_i386-sysroot/usr/lib/i386-linux-gnu");
+    let sysroot_path = PathBuf::from("./chromium/src/build/linux/debian_bullseye_i386-sysroot");
 
-    println!(
-        "cargo:rustc-link-arg=--sysroot=./chromium/src/build/linux/debian_bullseye_i386-sysroot"
-    );
+    if sysroot_path.is_dir() {
+        println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_i386-sysroot/lib/i386-linux-gnu");
+        println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_i386-sysroot/usr/lib/i386-linux-gnu");
+
+        println!(
+            "cargo:rustc-link-arg=--sysroot=./chromium/src/build/linux/debian_bullseye_i386-sysroot"
+        );
+    } else {
+        println!("cargo:warning={}", "x86 debian sysroot provided by chromium was not found!");
+        println!("cargo:warning={}", "carbonyl may fail to link against a proper libc!");
+    }
 }
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/lib/x86_64-linux-gnu");
+    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/usr/lib/x86_64-linux-gnu");
+    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot/usr");
+    println!("cargo:rustc-link-search=chromium/src/build/linux/debian_bullseye_amd64-sysroot");
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,7 @@ if [ -z "$CARBONYL_SKIP_CARGO_BUILD" ]; then
         export MACOSX_DEPLOYMENT_TARGET=10.13
     fi
 
-    cargo rustc --target "$triple" --release -- -C link-args='--sysroot ./chromium/src/build/linux/debian_bullseye_amd64-sysroot'
+    cargo build --target "$triple" --release
 fi
 
 if [ -f "build/$triple/release/libcarbonyl.dylib" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,7 @@ if [ -z "$CARBONYL_SKIP_CARGO_BUILD" ]; then
         export MACOSX_DEPLOYMENT_TARGET=10.13
     fi
 
-    cargo build --target "$triple" --release
+    cargo rustc --target "$triple" --release -- -C link-args='--sysroot ./chromium/src/build/linux/debian_bullseye_amd64-sysroot'
 fi
 
 if [ -f "build/$triple/release/libcarbonyl.dylib" ]; then


### PR DESCRIPTION
This branch adds a `build.rs` to the root of the project that makes sure that the Rust `carbonyl` lib links against the libc bundled with chromium.