### PR TITLE
Update tty.rs to support putty

### DIFF
--- a/src/input/tty.rs
+++ b/src/input/tty.rs
@@ -65,7 +65,7 @@ enum TTY {
     File(File),
 }
 
-const SEQUENCES: [(u32, bool); 4] = [(1049, true), (1003, true), (1006, true), (25, false)];
+const SEQUENCES: [(u32, bool); 5] = [(1049, true), (1002, true), (1003, true), (1006, true), (25, false)];
 
 impl TTY {
     fn stdin() -> TTY {


### PR DESCRIPTION
Add mode 1002 to tts, to make mouse works in Putty.
Fixes #140