### PR TITLE
Add build & release CI pipeline

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,107 @@
+name: Build & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version tag (e.g. v0.0.4)"
+        required: true
+        type: string
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+            artifact: carbonyl.macos-arm64
+          - os: macos-13
+            target: x86_64-apple-darwin
+            artifact: carbonyl.macos-amd64
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            artifact: carbonyl.linux-amd64
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 360
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build \
+            pkg-config \
+            libglib2.0-dev \
+            libatk1.0-dev \
+            libatk-bridge2.0-dev \
+            libcups2-dev \
+            libdrm-dev \
+            libxkbcommon-dev \
+            libxcomposite-dev \
+            libxdamage-dev \
+            libxrandr-dev \
+            libgbm-dev \
+            libpango1.0-dev \
+            libasound2-dev \
+            libnspr4-dev \
+            libnss3-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install ninja
+
+      - name: Sync Chromium (gclient)
+        run: scripts/gclient.sh
+
+      - name: Apply patches
+        run: scripts/patches.sh apply
+
+      - name: Configure (gn)
+        run: scripts/gn.sh Release ${{ matrix.target }}
+
+      - name: Build
+        run: scripts/build.sh Release
+
+      - name: Package
+        run: |
+          scripts/copy-binaries.sh Release
+          cd build/packages/Release
+          zip -r ${{ matrix.artifact }}.zip .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: build/packages/Release/${{ matrix.artifact }}.zip
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.version }}
+          name: Terminal Chromium ${{ inputs.version }}
+          files: artifacts/**/*.zip
+          generate_release_notes: true


### PR DESCRIPTION
Adds GitHub Actions workflow for building carbonyl from source and creating releases with pre-built binaries for macOS (arm64/amd64) and Linux (amd64).