### PR TITLE
feat(input): vimium-style keyboard navigation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,76 @@ $ carbonyl https://github.com
   </tbody>
 </table>
 
+## Keyboard navigation (vimium-style)
+
+Carbonyl ships with a built-in keyboard navigation layer modelled on
+[Vimium](https://github.com/philc/vimium). When no input field is focused, the
+following keys are handled by Carbonyl itself rather than forwarded to the
+page.
+
+### Scrolling
+
+| Key  | Action                       |
+| ---- | ---------------------------- |
+| `j`  | Scroll down one line         |
+| `k`  | Scroll up one line           |
+| `d`  | Scroll down half a page      |
+| `u`  | Scroll up half a page        |
+| `gg` | Scroll to the top            |
+| `G`  | Scroll to the bottom         |
+| `h`  | Send a Left arrow to the page (useful for carousels / horizontal scroll containers) |
+| `l`  | Send a Right arrow to the page |
+
+### History
+
+| Key | Action       |
+| --- | ------------ |
+| `H` | Go back      |
+| `L` | Go forward   |
+| `r` | Reload page  |
+
+### Find on page
+
+| Key   | Action                                       |
+| ----- | -------------------------------------------- |
+| `/`   | Open the find prompt (status bar at bottom)  |
+| Enter | Confirm the query and highlight matches      |
+| `n`   | Cycle to the next match                      |
+| `N`   | Cycle to the previous match                  |
+| `Esc` | Clear the active query and highlights        |
+
+Find searches the currently visible viewport only, ASCII case-insensitive.
+
+### Link hints
+
+| Key   | Action                                                                |
+| ----- | --------------------------------------------------------------------- |
+| `f`   | Show hint labels on the candidate clickables in the current viewport  |
+| `Esc` | Cancel hint mode                                                      |
+
+Type the label letters shown next to a target to send a synthetic click at that
+position. Single-letter labels are used when there are 26 or fewer candidates;
+longer labels appear otherwise. The status bar at the bottom shows how many
+candidates were found and what you have typed so far.
+
+Because Carbonyl does not currently expose the DOM to the Rust side, link
+candidates are detected from rendered text (short isolated runs, or runs whose
+colour differs from the dominant body colour). The label set is therefore a
+superset of the real anchors on the page: clicking a label that happens to land
+on plain text is harmless and simply does nothing.
+
+### Modes
+
+| Mode    | How to enter                                            | How to leave |
+| ------- | ------------------------------------------------------- | ------------ |
+| Normal  | Default whenever the URL bar is unfocused                | n/a          |
+| Insert  | `i`. Keys are passed through to the page (typing, etc.) | `Esc`        |
+| Find    | `/`                                                     | `Esc` or `Enter` |
+| Hint    | `f`                                                     | `Esc`, type a unique label, or type a prefix with no remaining matches |
+
+`Esc` in Normal mode also clears any leftover find highlights and pending
+prefixes (e.g. a half-typed `g`).
+
 ## Known issues
 
 - Fullscreen mode not supported yet

--- a/readme.md
+++ b/readme.md
@@ -69,10 +69,17 @@ $ carbonyl https://github.com
 
 ## Keyboard navigation (vimium-style)
 
-Carbonyl ships with a built-in keyboard navigation layer modelled on
-[Vimium](https://github.com/philc/vimium). When no input field is focused, the
-following keys are handled by Carbonyl itself rather than forwarded to the
-page.
+Carbonyl ships with an opt-in keyboard navigation layer modelled on
+[Vimium](https://github.com/philc/vimium). Enable it with `--vim` (or
+`CARBONYL_ENV_VIM=1`); it is off by default so every key reaches the page as
+usual. When enabled and the URL bar is unfocused, the following keys are
+handled by Carbonyl itself rather than forwarded to the page; press `i`
+(Insert mode) before typing into page inputs. Arrows, Enter and Tab always
+pass through.
+
+Note: the find highlights, hint labels and status bar are drawn as terminal
+cells, so they are not visible under `--graphics`; the scrolling and history
+keys still work there.
 
 ### Scrolling
 

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${CARBONYL_INSTALL_DIR:-$HOME/Downloads/carbonyl-0.0.3}"
+
+if [ ! -f "$INSTALL_DIR/libcarbonyl.dylib" ]; then
+    echo "libcarbonyl.dylib not found at $INSTALL_DIR"
+    echo "Set CARBONYL_INSTALL_DIR=<path> to point elsewhere."
+    exit 1
+fi
+
+ARCH="$(file "$INSTALL_DIR/libcarbonyl.dylib" | grep -oE 'x86_64|arm64')"
+case "$ARCH" in
+    x86_64) TARGET="x86_64-apple-darwin" ;;
+    arm64)  TARGET="aarch64-apple-darwin" ;;
+    *) echo "Unknown arch: $ARCH"; exit 1 ;;
+esac
+
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-10.13}"
+
+cd "$(dirname -- "$0")/.."
+
+rustup target add "$TARGET" >/dev/null 2>&1 || true
+
+cargo build --target "$TARGET" --release
+
+OUT="build/$TARGET/release/libcarbonyl.dylib"
+install_name_tool -id @executable_path/libcarbonyl.dylib "$OUT"
+cp "$OUT" "$INSTALL_DIR/libcarbonyl.dylib"
+
+echo "Installed $OUT -> $INSTALL_DIR/libcarbonyl.dylib"
+echo "Run: $INSTALL_DIR/carbonyl <url>"

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -344,6 +344,7 @@ pub extern "C" fn carbonyl_renderer_listen(bridge: RendererPtr, delegate: *mut B
         }
 
         listen(|mut events| {
+            let browser_height = bridge.lock().unwrap().window.browser.height as i32;
             bridge.lock().unwrap().renderer.render(move |renderer| {
                 let get_scale = || bridge.lock().unwrap().window.scale;
                 let scale = |col, row| {
@@ -359,6 +360,26 @@ pub extern "C" fn carbonyl_renderer_listen(bridge: RendererPtr, delegate: *mut B
                     match action {
                         NavigationAction::Ignore => (),
                         NavigationAction::Forward => return true,
+                        NavigationAction::KeyPress(char) => emit!(key_press(char as c_char)),
+                        NavigationAction::Scroll(delta) => emit!(scroll(delta as c_int)),
+                        NavigationAction::Click(col, row) => {
+                            let (px, py): (c_uint, c_uint) =
+                                scale(col as usize, row as usize);
+                            let md = delegate.mouse_down;
+                            let mu = delegate.mouse_up;
+                            let post_task_fn = delegate.post_task;
+                            // Two separate posts (mouse_down now, mouse_up after a short
+                            // delay on a side thread) so blink registers down/up as a
+                            // proper click without the browser main thread blocking on
+                            // sleep.
+                            let run_down = move || md(px, py);
+                            unsafe { post_task(post_task_fn, run_down) }
+                            std::thread::spawn(move || {
+                                std::thread::sleep(std::time::Duration::from_millis(80));
+                                let run_up = move || mu(px, py);
+                                unsafe { post_task(post_task_fn, run_up) }
+                            });
+                        }
                         NavigationAction::GoBack() => emit!(go_back()),
                         NavigationAction::GoForward() => emit!(go_forward()),
                         NavigationAction::Refresh() => emit!(refresh()),
@@ -383,7 +404,7 @@ pub extern "C" fn carbonyl_renderer_listen(bridge: RendererPtr, delegate: *mut B
                             emit!(scroll((delta as f32 * scale.height) as c_int))
                         }
                         KeyPress { key } => {
-                            if dispatch(renderer.keypress(&key).unwrap()) {
+                            if dispatch(renderer.keypress(&key, browser_height).unwrap()) {
                                 emit!(key_press(key.char as c_char))
                             }
                         }

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -9,7 +9,7 @@ pub struct CommandLine {
     pub zoom: f32,
     pub debug: bool,
     pub bitmap: bool,
-    pub no_vim: bool,
+    pub vim: bool,
     pub program: CommandLineProgram,
     pub shell_mode: bool,
 }
@@ -18,7 +18,7 @@ pub enum EnvVar {
     Debug,
     Bitmap,
     ShellMode,
-    NoVim,
+    Vim,
 }
 
 impl EnvVar {
@@ -27,7 +27,7 @@ impl EnvVar {
             EnvVar::Debug => "CARBONYL_ENV_DEBUG",
             EnvVar::Bitmap => "CARBONYL_ENV_BITMAP",
             EnvVar::ShellMode => "CARBONYL_ENV_SHELL_MODE",
-            EnvVar::NoVim => "CARBONYL_ENV_NO_VIM",
+            EnvVar::Vim => "CARBONYL_ENV_VIM",
         }
     }
 }
@@ -44,7 +44,7 @@ impl CommandLine {
         let mut zoom = 1.0;
         let mut debug = false;
         let mut bitmap = false;
-        let mut no_vim = false;
+        let mut vim = false;
         let mut shell_mode = false;
         let mut program = CommandLineProgram::Main;
         let args = env::args().skip(1).collect::<Vec<String>>();
@@ -81,7 +81,7 @@ impl CommandLine {
                 "-z" | "--zoom" => set_f32!(zoom = zoom / 100.0),
                 "-d" | "--debug" => set!(debug, Debug),
                 "-b" | "--bitmap" => set!(bitmap, Bitmap),
-                "--no-vim" => set!(no_vim, NoVim),
+                "--vim" => set!(vim, Vim),
 
                 "-h" | "--help" => program = CommandLineProgram::Help,
                 "-v" | "--version" => program = CommandLineProgram::Version,
@@ -101,8 +101,8 @@ impl CommandLine {
             shell_mode = true;
         }
 
-        if env::var(EnvVar::NoVim).is_ok() {
-            no_vim = true;
+        if env::var(EnvVar::Vim).is_ok() {
+            vim = true;
         }
 
         CommandLine {
@@ -111,7 +111,7 @@ impl CommandLine {
             zoom,
             debug,
             bitmap,
-            no_vim,
+            vim,
             program,
             shell_mode,
         }

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -9,6 +9,7 @@ pub struct CommandLine {
     pub zoom: f32,
     pub debug: bool,
     pub bitmap: bool,
+    pub no_vim: bool,
     pub program: CommandLineProgram,
     pub shell_mode: bool,
 }
@@ -17,6 +18,7 @@ pub enum EnvVar {
     Debug,
     Bitmap,
     ShellMode,
+    NoVim,
 }
 
 impl EnvVar {
@@ -25,6 +27,7 @@ impl EnvVar {
             EnvVar::Debug => "CARBONYL_ENV_DEBUG",
             EnvVar::Bitmap => "CARBONYL_ENV_BITMAP",
             EnvVar::ShellMode => "CARBONYL_ENV_SHELL_MODE",
+            EnvVar::NoVim => "CARBONYL_ENV_NO_VIM",
         }
     }
 }
@@ -41,6 +44,7 @@ impl CommandLine {
         let mut zoom = 1.0;
         let mut debug = false;
         let mut bitmap = false;
+        let mut no_vim = false;
         let mut shell_mode = false;
         let mut program = CommandLineProgram::Main;
         let args = env::args().skip(1).collect::<Vec<String>>();
@@ -77,6 +81,7 @@ impl CommandLine {
                 "-z" | "--zoom" => set_f32!(zoom = zoom / 100.0),
                 "-d" | "--debug" => set!(debug, Debug),
                 "-b" | "--bitmap" => set!(bitmap, Bitmap),
+                "--no-vim" => set!(no_vim, NoVim),
 
                 "-h" | "--help" => program = CommandLineProgram::Help,
                 "-v" | "--version" => program = CommandLineProgram::Version,
@@ -96,12 +101,17 @@ impl CommandLine {
             shell_mode = true;
         }
 
+        if env::var(EnvVar::NoVim).is_ok() {
+            no_vim = true;
+        }
+
         CommandLine {
             args,
             fps,
             zoom,
             debug,
             bitmap,
+            no_vim,
             program,
             shell_mode,
         }

--- a/src/cli/usage.txt
+++ b/src/cli/usage.txt
@@ -11,8 +11,7 @@ Options:
     -z, --zoom=<zoom>          set the zoom level in percent (default: 100)
     -b, --bitmap               render text as bitmaps
     -d, --debug                enable debug logs
-        --no-vim               disable built-in vimium-style keyboard navigation
-                               (forward every key to the page, e.g. when the
-                               page has its own keymap)
+        --vim                  enable vimium-style keyboard navigation
+                               (h/j/k/l scroll, f link hints, / find)
     -h, --help                 display this help message
     -v, --version              output the version number

--- a/src/cli/usage.txt
+++ b/src/cli/usage.txt
@@ -11,5 +11,8 @@ Options:
     -z, --zoom=<zoom>          set the zoom level in percent (default: 100)
     -b, --bitmap               render text as bitmaps
     -d, --debug                enable debug logs
+        --no-vim               disable built-in vimium-style keyboard navigation
+                               (forward every key to the page, e.g. when the
+                               page has its own keymap)
     -h, --help                 display this help message
     -v, --version              output the version number

--- a/src/output/renderer.rs
+++ b/src/output/renderer.rs
@@ -10,6 +10,7 @@ use crate::{
     gfx::{Color, Point, Rect, Size},
     input::Key,
     ui::navigation::{Navigation, NavigationAction},
+    ui::vimium::{HintTarget, Mode},
     utils::log,
 };
 
@@ -20,6 +21,7 @@ pub struct Renderer {
     cells: Vec<(Cell, Cell)>,
     painter: Painter,
     size: Size,
+    overlay_restore: Vec<(usize, Cell)>,
 }
 
 impl Renderer {
@@ -29,6 +31,7 @@ impl Renderer {
             cells: Vec::with_capacity(0),
             painter: Painter::new(),
             size: Size::new(0, 0),
+            overlay_restore: Vec::new(),
         }
     }
 
@@ -36,10 +39,18 @@ impl Renderer {
         self.painter.set_true_color(true)
     }
 
-    pub fn keypress(&mut self, key: &Key) -> io::Result<NavigationAction> {
-        let action = self.nav.keypress(key);
+    pub fn keypress(&mut self, key: &Key, viewport_px_height: i32) -> io::Result<NavigationAction> {
+        let action = self.nav.keypress(key, viewport_px_height);
 
         Ok(action)
+    }
+
+    pub fn nav(&self) -> &Navigation {
+        &self.nav
+    }
+
+    pub fn cells_size(&self) -> Size {
+        self.size
     }
     pub fn mouse_up(&mut self, origin: Point) -> io::Result<NavigationAction> {
         let action = self.nav.mouse_up(origin);
@@ -68,6 +79,7 @@ impl Renderer {
     pub fn set_size(&mut self, size: Size) {
         self.nav.set_size(size);
         self.size = size;
+        self.overlay_restore.clear();
 
         let mut x = 0;
         let mut y = 0;
@@ -92,6 +104,8 @@ impl Renderer {
     pub fn render(&mut self) -> io::Result<()> {
         let size = self.size;
 
+        self.restore_overlay();
+
         for (origin, element) in self.nav.render(size) {
             self.fill_rect(
                 Rect::new(origin.x, origin.y, element.text.width() as u32, 1),
@@ -104,6 +118,8 @@ impl Renderer {
                 element.foreground,
             );
         }
+
+        self.render_vimium_overlay();
 
         self.painter.begin()?;
 
@@ -281,4 +297,423 @@ impl Renderer {
             }
         }
     }
+
+    fn restore_overlay(&mut self) {
+        let len = self.cells.len();
+        for (idx, original) in std::mem::take(&mut self.overlay_restore) {
+            if idx < len {
+                let (_, cell) = &mut self.cells[idx];
+                cell.quadrant = original.quadrant;
+                cell.grapheme = original.grapheme;
+            }
+        }
+    }
+
+    fn snapshot_cell(&mut self, idx: usize) {
+        if let Some((_, cell)) = self.cells.get(idx) {
+            self.overlay_restore.push((
+                idx,
+                Cell {
+                    cursor: cell.cursor,
+                    grapheme: cell.grapheme.clone(),
+                    quadrant: cell.quadrant,
+                },
+            ));
+        }
+    }
+
+    fn render_vimium_overlay(&mut self) {
+        let viewport_w = self.size.width as usize;
+        let viewport_h = self.size.height as usize;
+        if viewport_w == 0 || viewport_h == 0 {
+            return;
+        }
+        let mode = self.nav.vimium_mode();
+
+        if mode == Mode::Hint && self.nav.vimium_hints().is_empty() {
+            let targets = self.build_hint_targets(viewport_w, viewport_h);
+            if targets.is_empty() {
+                self.nav.vimium_exit_hint();
+            } else {
+                self.nav.vimium_set_hints(targets);
+            }
+        }
+        let mode = self.nav.vimium_mode();
+
+        let status_text = match mode {
+            Mode::Find => Some(format!("/{}", self.nav.vimium_find_buf())),
+            Mode::Insert => Some("-- INSERT --".to_string()),
+            Mode::Hint => Some(format!(
+                "hint ({} link{}): {}  [esc to cancel]",
+                self.nav.vimium_hints().len(),
+                if self.nav.vimium_hints().len() == 1 { "" } else { "s" },
+                self.nav.vimium_hint_buf()
+            )),
+            Mode::Normal => match self.nav.vimium_find_query() {
+                Some(q) => Some(format!("/{}", q)),
+                None => None,
+            },
+        };
+
+        let mut matches: Vec<(usize, usize, usize)> = Vec::new();
+        let find_query = self
+            .nav
+            .vimium_find_query()
+            .map(|s| s.to_ascii_lowercase());
+        let find_cursor = self.nav.vimium_find_cursor();
+
+        if let Some(query) = &find_query {
+            if !query.is_empty() {
+                matches = self.find_matches(query, viewport_w, viewport_h);
+            }
+        }
+
+        if let Some(text) = &status_text {
+            let suffix = if matches.is_empty() && find_query.is_some() {
+                " (no matches)".to_string()
+            } else if !matches.is_empty() {
+                let cur = find_cursor % matches.len();
+                format!(" [{}/{}]", cur + 1, matches.len())
+            } else {
+                String::new()
+            };
+            let full = format!("{}{}", text, suffix);
+            let row = viewport_h.saturating_sub(1).max(1);
+            let bg = Color::splat(20);
+            let fg = Color::new(255, 255, 255);
+            let max_chars = viewport_w.saturating_sub(1);
+            let printed: String = full.chars().take(max_chars).collect();
+            self.overlay_row(row, viewport_w, bg);
+            self.overlay_text(&printed, row, viewport_w, fg);
+        }
+
+        if !matches.is_empty() {
+            let current_idx = find_cursor % matches.len();
+            let highlight_bg = Color::new(255, 235, 110);
+            let current_bg = Color::new(255, 150, 50);
+            for (i, (row, c_start, c_end)) in matches.iter().enumerate() {
+                let bg = if i == current_idx {
+                    current_bg
+                } else {
+                    highlight_bg
+                };
+                let row_off = row * viewport_w;
+                for col in *c_start..*c_end {
+                    let idx = row_off + col;
+                    self.snapshot_cell(idx);
+                    if let Some((_, cell)) = self.cells.get_mut(idx) {
+                        cell.quadrant = (bg, bg, bg, bg);
+                    }
+                }
+            }
+        }
+
+        if mode == Mode::Hint {
+            let buf = self.nav.vimium_hint_buf().to_string();
+            let hints: Vec<HintTarget> = self
+                .nav
+                .vimium_hints()
+                .iter()
+                .filter(|h| h.label.starts_with(&buf))
+                .cloned()
+                .collect();
+            let label_bg = Color::new(255, 220, 60);
+            let label_fg = Color::splat(0);
+            let typed_fg = Color::new(140, 60, 0);
+            for hint in &hints {
+                let row = hint.row as usize;
+                if row == 0 || row >= viewport_h {
+                    continue;
+                }
+                let row_off = row * viewport_w;
+                let label_len = hint.label.chars().count();
+                let start_col = hint.col_start as usize;
+                for i in 0..label_len {
+                    let col = start_col + i;
+                    if col >= viewport_w {
+                        break;
+                    }
+                    let idx = row_off + col;
+                    self.snapshot_cell(idx);
+                    let ch = hint.label.chars().nth(i).unwrap_or(' ');
+                    let fg = if i < buf.len() { typed_fg } else { label_fg };
+                    if let Some((_, cell)) = self.cells.get_mut(idx) {
+                        cell.quadrant = (label_bg, label_bg, label_bg, label_bg);
+                        cell.grapheme = Some(Rc::new(Grapheme {
+                            char: ch.to_string(),
+                            index: 0,
+                            width: 1,
+                            color: fg,
+                        }));
+                    }
+                }
+            }
+        }
+    }
+
+    fn build_hint_targets(&self, viewport_w: usize, viewport_h: usize) -> Vec<HintTarget> {
+        let dominant = self.dominant_text_color(viewport_w, viewport_h);
+        // Step 1: walk cells per row, build same-color contiguous text spans.
+        // A new span starts on a color change or whitespace boundary.
+        let mut spans: Vec<(u32, u32, u32, Color)> = Vec::new();
+        for row in 1..=viewport_h {
+            let row_off = row * viewport_w;
+            if row_off + viewport_w > self.cells.len() {
+                break;
+            }
+            let mut col = 0usize;
+            let mut current: Option<(usize, Color)> = None;
+            while col < viewport_w {
+                let cell = &self.cells[row_off + col].1;
+                let info = match &cell.grapheme {
+                    Some(g) if g.index == 0 => {
+                        let ch = g.char.chars().next().unwrap_or(' ');
+                        if ch.is_whitespace() {
+                            None
+                        } else {
+                            Some((g.color, g.width.max(1)))
+                        }
+                    }
+                    Some(_) => Some((Color::black(), 1)),
+                    None => None,
+                };
+                match (current, info) {
+                    (Some((start, color)), Some((c, w))) => {
+                        if color_distance(color, c) < 15 {
+                            col += w;
+                        } else {
+                            spans.push((row as u32, start as u32, col as u32, color));
+                            current = Some((col, c));
+                            col += w;
+                        }
+                    }
+                    (Some((start, color)), None) => {
+                        spans.push((row as u32, start as u32, col as u32, color));
+                        current = None;
+                        col += 1;
+                    }
+                    (None, Some((c, w))) => {
+                        current = Some((col, c));
+                        col += w;
+                    }
+                    (None, None) => {
+                        col += 1;
+                    }
+                }
+            }
+            if let Some((start, color)) = current {
+                spans.push((row as u32, start as u32, col as u32, color));
+            }
+        }
+
+        // Step 2: merge adjacent same-color spans on the same row with a 1-cell
+        // gap (single whitespace). Body paragraphs collapse into one wide span;
+        // nav menu items separated by multiple spaces stay distinct.
+        let mut merged: Vec<(u32, u32, u32, Color)> = Vec::new();
+        for span in spans {
+            let (row, start, end, color) = span;
+            let can_merge = merged.last().map_or(false, |&(r, _, last_end, last_color)| {
+                r == row
+                    && start.saturating_sub(last_end) <= 1
+                    && color_distance(color, last_color) < 15
+            });
+            if can_merge {
+                merged.last_mut().unwrap().2 = end;
+            } else {
+                merged.push((row, start, end, color));
+            }
+        }
+
+        // Step 3: keep spans that are either short (likely a button/link/label)
+        // or visually distinct from the dominant text color (likely a styled
+        // link in body content).
+        let max_width = 30u32;
+        let filtered: Vec<(u32, u32, u32)> = merged
+            .into_iter()
+            .filter(|(_, s, e, color)| {
+                let width = e.saturating_sub(*s);
+                let differs_from_dominant = dominant
+                    .map(|d| color_distance(*color, d) >= 60)
+                    .unwrap_or(true);
+                width >= 1 && (width <= max_width || differs_from_dominant)
+            })
+            .map(|(r, s, e, _)| (r, s, e))
+            .collect();
+
+        let labels = make_hint_labels(filtered.len());
+        filtered
+            .into_iter()
+            .zip(labels.into_iter())
+            .map(|((row, col_start, col_end), label)| HintTarget {
+                label,
+                row,
+                col_start,
+                col_end,
+            })
+            .collect()
+    }
+
+    fn dominant_text_color(&self, viewport_w: usize, viewport_h: usize) -> Option<Color> {
+        let mut buckets: Vec<(Color, usize)> = Vec::new();
+        for row in 1..=viewport_h {
+            let row_off = row * viewport_w;
+            if row_off + viewport_w > self.cells.len() {
+                break;
+            }
+            for col in 0..viewport_w {
+                let cell = &self.cells[row_off + col].1;
+                if let Some(g) = &cell.grapheme {
+                    if g.index != 0 {
+                        continue;
+                    }
+                    if g.char.chars().next().map(|c| c.is_whitespace()).unwrap_or(true) {
+                        continue;
+                    }
+                    let c = g.color;
+                    if let Some(slot) = buckets.iter_mut().find(|(b, _)| *b == c) {
+                        slot.1 += 1;
+                    } else {
+                        buckets.push((c, 1));
+                    }
+                }
+            }
+        }
+        buckets.into_iter().max_by_key(|(_, n)| *n).map(|(c, _)| c)
+    }
+
+    fn overlay_row(&mut self, row: usize, viewport_w: usize, bg: Color) {
+        let row_off = row * viewport_w;
+        for col in 0..viewport_w {
+            let idx = row_off + col;
+            self.snapshot_cell(idx);
+            if let Some((_, cell)) = self.cells.get_mut(idx) {
+                cell.quadrant = (bg, bg, bg, bg);
+                cell.grapheme = None;
+            }
+        }
+    }
+
+    fn overlay_text(&mut self, text: &str, row: usize, viewport_w: usize, fg: Color) {
+        let row_off = row * viewport_w;
+        let mut col = 0usize;
+        for grapheme in UnicodeSegmentation::graphemes(text, true) {
+            let width = grapheme.width().max(1);
+            if col >= viewport_w {
+                break;
+            }
+            for i in 0..width {
+                if col + i >= viewport_w {
+                    return;
+                }
+                let idx = row_off + col + i;
+                if let Some((_, cell)) = self.cells.get_mut(idx) {
+                    cell.grapheme = Some(Rc::new(Grapheme {
+                        char: grapheme.to_string(),
+                        index: i,
+                        width,
+                        color: fg,
+                    }));
+                }
+            }
+            col += width;
+        }
+    }
+
+    fn find_matches(
+        &self,
+        query: &str,
+        viewport_w: usize,
+        viewport_h: usize,
+    ) -> Vec<(usize, usize, usize)> {
+        let mut out = Vec::new();
+        let max_row = viewport_h;
+        for row in 1..=max_row {
+            let row_off = row * viewport_w;
+            if row_off + viewport_w > self.cells.len() {
+                break;
+            }
+            let mut row_text = String::new();
+            let mut byte_to_col: Vec<(usize, usize)> = Vec::new();
+            let mut col = 0usize;
+            while col < viewport_w {
+                let cell = &self.cells[row_off + col].1;
+                if let Some(g) = &cell.grapheme {
+                    if g.index == 0 {
+                        byte_to_col.push((row_text.len(), col));
+                        row_text.push_str(&g.char);
+                        col += g.width.max(1);
+                        continue;
+                    }
+                }
+                byte_to_col.push((row_text.len(), col));
+                row_text.push(' ');
+                col += 1;
+            }
+            let row_lower = row_text.to_ascii_lowercase();
+            let mut start_byte = 0usize;
+            while start_byte <= row_lower.len() {
+                let slice = &row_lower[start_byte..];
+                let Some(rel) = slice.find(query) else { break };
+                let abs_byte = start_byte + rel;
+                let end_byte = abs_byte + query.len();
+                let col_start = byte_to_col
+                    .iter()
+                    .rev()
+                    .find(|(b, _)| *b <= abs_byte)
+                    .map(|(_, c)| *c)
+                    .unwrap_or(0);
+                let col_end = byte_to_col
+                    .iter()
+                    .find(|(b, _)| *b >= end_byte)
+                    .map(|(_, c)| *c)
+                    .unwrap_or(viewport_w);
+                let col_end = col_end.max(col_start + 1);
+                out.push((row, col_start, col_end));
+                start_byte = abs_byte + query.len().max(1);
+            }
+        }
+        out
+    }
+}
+
+fn color_distance(a: Color, b: Color) -> u32 {
+    let dr = (a.r as i32 - b.r as i32).unsigned_abs();
+    let dg = (a.g as i32 - b.g as i32).unsigned_abs();
+    let db = (a.b as i32 - b.b as i32).unsigned_abs();
+    dr + dg + db
+}
+
+fn make_hint_labels(n: usize) -> Vec<String> {
+    if n == 0 {
+        return Vec::new();
+    }
+    if n <= 26 {
+        return (0..n)
+            .map(|i| ((b'a' + i as u8) as char).to_string())
+            .collect();
+    }
+    if n <= 26 * 26 {
+        return (0..n)
+            .map(|i| {
+                let hi = i / 26;
+                let lo = i % 26;
+                let mut s = String::new();
+                s.push((b'a' + hi as u8) as char);
+                s.push((b'a' + lo as u8) as char);
+                s
+            })
+            .collect();
+    }
+    (0..n)
+        .map(|i| {
+            let h = i / (26 * 26);
+            let m = (i / 26) % 26;
+            let l = i % 26;
+            let mut s = String::new();
+            s.push((b'a' + h as u8) as char);
+            s.push((b'a' + m as u8) as char);
+            s.push((b'a' + l as u8) as char);
+            s
+        })
+        .collect()
 }

--- a/src/output/renderer.rs
+++ b/src/output/renderer.rs
@@ -300,7 +300,10 @@ impl Renderer {
 
     fn restore_overlay(&mut self) {
         let len = self.cells.len();
-        for (idx, original) in std::mem::take(&mut self.overlay_restore) {
+        // Overlays can snapshot the same cell twice in one frame (e.g. a find
+        // match under the status bar); only the first snapshot holds page
+        // content, so restore in reverse to make it win.
+        for (idx, original) in std::mem::take(&mut self.overlay_restore).into_iter().rev() {
             if idx < len {
                 let (_, cell) = &mut self.cells[idx];
                 cell.quadrant = original.quadrant;
@@ -368,25 +371,6 @@ impl Renderer {
             }
         }
 
-        if let Some(text) = &status_text {
-            let suffix = if matches.is_empty() && find_query.is_some() {
-                " (no matches)".to_string()
-            } else if !matches.is_empty() {
-                let cur = find_cursor % matches.len();
-                format!(" [{}/{}]", cur + 1, matches.len())
-            } else {
-                String::new()
-            };
-            let full = format!("{}{}", text, suffix);
-            let row = viewport_h.saturating_sub(1).max(1);
-            let bg = Color::splat(20);
-            let fg = Color::new(255, 255, 255);
-            let max_chars = viewport_w.saturating_sub(1);
-            let printed: String = full.chars().take(max_chars).collect();
-            self.overlay_row(row, viewport_w, bg);
-            self.overlay_text(&printed, row, viewport_w, fg);
-        }
-
         if !matches.is_empty() {
             let current_idx = find_cursor % matches.len();
             let highlight_bg = Color::new(255, 235, 110);
@@ -448,6 +432,27 @@ impl Renderer {
                     }
                 }
             }
+        }
+
+        // Status bar last so match highlights and hint labels on the bottom
+        // row can't paint over it.
+        if let Some(text) = &status_text {
+            let suffix = if matches.is_empty() && find_query.is_some() {
+                " (no matches)".to_string()
+            } else if !matches.is_empty() {
+                let cur = find_cursor % matches.len();
+                format!(" [{}/{}]", cur + 1, matches.len())
+            } else {
+                String::new()
+            };
+            let full = format!("{}{}", text, suffix);
+            let row = viewport_h.saturating_sub(1).max(1);
+            let bg = Color::splat(20);
+            let fg = Color::new(255, 255, 255);
+            let max_chars = viewport_w.saturating_sub(1);
+            let printed: String = full.chars().take(max_chars).collect();
+            self.overlay_row(row, viewport_w, bg);
+            self.overlay_text(&printed, row, viewport_w, fg);
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,1 +1,2 @@
 pub mod navigation;
+pub mod vimium;

--- a/src/ui/navigation.rs
+++ b/src/ui/navigation.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use unicode_width::UnicodeWidthStr;
 
+use super::vimium::{HintTarget, Mode, Vimium};
 use crate::{
     gfx::{Color, Point, Size},
     input::Key,
@@ -11,6 +12,9 @@ use crate::{
 pub enum NavigationAction {
     Ignore,
     Forward,
+    KeyPress(u8),
+    Scroll(i32),
+    Click(u32, u32),
     GoTo(String),
     GoBack(),
     GoForward(),
@@ -30,6 +34,7 @@ pub struct Navigation {
     cursor: Option<usize>,
     can_go_back: bool,
     can_go_forward: bool,
+    vimium: Vimium,
 }
 
 impl Navigation {
@@ -40,6 +45,7 @@ impl Navigation {
             cursor: None,
             can_go_back: false,
             can_go_forward: false,
+            vimium: Vimium::new(),
         }
     }
 
@@ -47,18 +53,54 @@ impl Navigation {
         Some((11 + self.cursor? as i32, 0).into())
     }
 
-    pub fn keypress(&mut self, key: &Key) -> NavigationAction {
+    pub fn vimium_mode(&self) -> Mode {
+        self.vimium.mode()
+    }
+
+    pub fn vimium_find_buf(&self) -> &str {
+        self.vimium.find_buf()
+    }
+
+    pub fn vimium_find_query(&self) -> Option<&str> {
+        self.vimium.find_query()
+    }
+
+    pub fn vimium_find_cursor(&self) -> usize {
+        self.vimium.find_cursor()
+    }
+
+    pub fn vimium_hints(&self) -> &[HintTarget] {
+        self.vimium.hints()
+    }
+
+    pub fn vimium_hint_buf(&self) -> &str {
+        self.vimium.hint_buf()
+    }
+
+    pub fn vimium_set_hints(&mut self, hints: Vec<HintTarget>) {
+        self.vimium.set_hints(hints)
+    }
+
+    pub fn vimium_exit_hint(&mut self) {
+        self.vimium.exit_hint()
+    }
+
+    pub fn keypress(&mut self, key: &Key, viewport_px_height: i32) -> NavigationAction {
         let modifier_key = match env::consts::OS {
             "macos" => key.modifiers.meta,
             _ => key.modifiers.alt,
         };
 
         match self.cursor {
-            None => match (modifier_key, key.char) {
-                (true, 0x14) => NavigationAction::GoBack(),
-                (true, 0x13) => NavigationAction::GoForward(),
-                _ => NavigationAction::Forward,
-            },
+            None => {
+                if let (true, 0x14) = (modifier_key, key.char) {
+                    return NavigationAction::GoBack();
+                }
+                if let (true, 0x13) = (modifier_key, key.char) {
+                    return NavigationAction::GoForward();
+                }
+                self.vimium.handle(key, viewport_px_height)
+            }
             Some(cursor) => {
                 if let Some(url) = &mut self.url {
                     // TODO: Unicode

--- a/src/ui/vimium.rs
+++ b/src/ui/vimium.rs
@@ -1,3 +1,4 @@
+use crate::cli::CommandLine;
 use crate::input::Key;
 
 use super::navigation::NavigationAction;
@@ -37,9 +38,10 @@ pub struct Vimium {
     find_cursor: usize,
     hints: Vec<HintTarget>,
     hint_buf: String,
-    // When set, every key is forwarded to the page unchanged. `--no-vim` on
-    // the CLI flips this on so pages with their own keymap (e.g. slop-review)
-    // get the full key stream instead of fighting vimium for j/k/gg/etc.
+    // Off by default: every key forwards to the page unchanged, like stock
+    // carbonyl. `--vim` opts in, mirroring how `--graphics` gates the kitty
+    // renderer, so pages with their own keymap keep the full key stream
+    // unless the user asks for vimium.
     disabled: bool,
 }
 
@@ -53,7 +55,7 @@ impl Vimium {
             find_cursor: 0,
             hints: Vec::new(),
             hint_buf: String::new(),
-            disabled: std::env::var("CARBONYL_ENV_NO_VIM").is_ok(),
+            disabled: !CommandLine::parse().vim,
         }
     }
 
@@ -242,6 +244,10 @@ impl Vimium {
                 self.hints.clear();
                 NavigationAction::Ignore
             }
+            // Arrows (0x11-0x14), Enter, Tab, backspace. Swallowing these
+            // would kill basic page interaction (focus cycling, link
+            // activation), so pass them through.
+            c if c < 0x20 || c == 0x7f => NavigationAction::Forward,
             _ => NavigationAction::Ignore,
         }
     }

--- a/src/ui/vimium.rs
+++ b/src/ui/vimium.rs
@@ -37,6 +37,10 @@ pub struct Vimium {
     find_cursor: usize,
     hints: Vec<HintTarget>,
     hint_buf: String,
+    // When set, every key is forwarded to the page unchanged. `--no-vim` on
+    // the CLI flips this on so pages with their own keymap (e.g. slop-review)
+    // get the full key stream instead of fighting vimium for j/k/gg/etc.
+    disabled: bool,
 }
 
 impl Vimium {
@@ -49,6 +53,7 @@ impl Vimium {
             find_cursor: 0,
             hints: Vec::new(),
             hint_buf: String::new(),
+            disabled: std::env::var("CARBONYL_ENV_NO_VIM").is_ok(),
         }
     }
 
@@ -87,6 +92,10 @@ impl Vimium {
     }
 
     pub fn handle(&mut self, key: &Key, viewport_px_height: i32) -> NavigationAction {
+        if self.disabled {
+            return NavigationAction::Forward;
+        }
+
         let line_step = (viewport_px_height / 16).max(40);
         let half_page = (viewport_px_height / 2).max(line_step);
 

--- a/src/ui/vimium.rs
+++ b/src/ui/vimium.rs
@@ -1,0 +1,239 @@
+use crate::input::Key;
+
+use super::navigation::NavigationAction;
+
+const SCROLL_TO_EDGE_PX: i32 = 1_000_000_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Normal,
+    Insert,
+    Find,
+    Hint,
+}
+
+#[derive(Debug, Clone)]
+pub struct HintTarget {
+    pub label: String,
+    pub row: u32,
+    pub col_start: u32,
+    pub col_end: u32,
+}
+
+impl HintTarget {
+    pub fn click_col(&self) -> u32 {
+        (self.col_start + self.col_end.saturating_sub(1)) / 2
+    }
+    pub fn click_row(&self) -> u32 {
+        self.row
+    }
+}
+
+pub struct Vimium {
+    mode: Mode,
+    pending_g: bool,
+    find_buf: String,
+    find_query: Option<String>,
+    find_cursor: usize,
+    hints: Vec<HintTarget>,
+    hint_buf: String,
+}
+
+impl Vimium {
+    pub fn new() -> Self {
+        Self {
+            mode: Mode::Normal,
+            pending_g: false,
+            find_buf: String::new(),
+            find_query: None,
+            find_cursor: 0,
+            hints: Vec::new(),
+            hint_buf: String::new(),
+        }
+    }
+
+    pub fn hints(&self) -> &[HintTarget] {
+        &self.hints
+    }
+
+    pub fn hint_buf(&self) -> &str {
+        &self.hint_buf
+    }
+
+    pub fn set_hints(&mut self, hints: Vec<HintTarget>) {
+        self.hints = hints;
+    }
+
+    pub fn exit_hint(&mut self) {
+        self.hints.clear();
+        self.hint_buf.clear();
+        self.mode = Mode::Normal;
+    }
+
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    pub fn find_buf(&self) -> &str {
+        &self.find_buf
+    }
+
+    pub fn find_query(&self) -> Option<&str> {
+        self.find_query.as_deref()
+    }
+
+    pub fn find_cursor(&self) -> usize {
+        self.find_cursor
+    }
+
+    pub fn handle(&mut self, key: &Key, viewport_px_height: i32) -> NavigationAction {
+        let line_step = (viewport_px_height / 16).max(40);
+        let half_page = (viewport_px_height / 2).max(line_step);
+
+        match self.mode {
+            Mode::Insert => self.handle_insert(key),
+            Mode::Find => self.handle_find(key),
+            Mode::Hint => self.handle_hint(key),
+            Mode::Normal => self.handle_normal(key, line_step, half_page),
+        }
+    }
+
+    fn handle_hint(&mut self, key: &Key) -> NavigationAction {
+        match key.char {
+            0x1b => {
+                self.exit_hint();
+                NavigationAction::Ignore
+            }
+            0x7f | 0x08 => {
+                self.hint_buf.pop();
+                NavigationAction::Ignore
+            }
+            c if c.is_ascii_alphabetic() => {
+                self.hint_buf.push((c as char).to_ascii_lowercase());
+                let buf = self.hint_buf.as_str();
+                let mut last_match: Option<(u32, u32)> = None;
+                let mut count = 0usize;
+                for h in &self.hints {
+                    if h.label.starts_with(buf) {
+                        count += 1;
+                        last_match = Some((h.click_col(), h.click_row()));
+                        if count > 1 {
+                            break;
+                        }
+                    }
+                }
+                if count == 1 {
+                    let (col, row) = last_match.unwrap();
+                    self.exit_hint();
+                    return NavigationAction::Click(col, row);
+                }
+                if count == 0 {
+                    self.exit_hint();
+                }
+                NavigationAction::Ignore
+            }
+            _ => NavigationAction::Ignore,
+        }
+    }
+
+    fn handle_insert(&mut self, key: &Key) -> NavigationAction {
+        if key.char == 0x1b {
+            self.mode = Mode::Normal;
+            return NavigationAction::Ignore;
+        }
+        NavigationAction::Forward
+    }
+
+    fn handle_find(&mut self, key: &Key) -> NavigationAction {
+        match key.char {
+            0x1b => {
+                self.mode = Mode::Normal;
+                self.find_buf.clear();
+                NavigationAction::Ignore
+            }
+            0x0d => {
+                self.find_query = if self.find_buf.is_empty() {
+                    None
+                } else {
+                    Some(self.find_buf.clone())
+                };
+                self.find_cursor = 0;
+                self.find_buf.clear();
+                self.mode = Mode::Normal;
+                NavigationAction::Ignore
+            }
+            0x7f | 0x08 => {
+                if self.find_buf.pop().is_none() {
+                    self.mode = Mode::Normal;
+                }
+                NavigationAction::Ignore
+            }
+            c if (0x20..0x7f).contains(&c) => {
+                self.find_buf.push(c as char);
+                NavigationAction::Ignore
+            }
+            _ => NavigationAction::Ignore,
+        }
+    }
+
+    fn handle_normal(&mut self, key: &Key, line_step: i32, half_page: i32) -> NavigationAction {
+        if self.pending_g {
+            self.pending_g = false;
+            return match key.char {
+                b'g' => NavigationAction::Scroll(SCROLL_TO_EDGE_PX),
+                _ => NavigationAction::Ignore,
+            };
+        }
+
+        match key.char {
+            0x1b => {
+                self.pending_g = false;
+                self.find_query = None;
+                self.find_cursor = 0;
+                NavigationAction::Ignore
+            }
+            b'i' => {
+                self.mode = Mode::Insert;
+                NavigationAction::Ignore
+            }
+            b'/' => {
+                self.mode = Mode::Find;
+                self.find_buf.clear();
+                NavigationAction::Ignore
+            }
+            b'h' => NavigationAction::KeyPress(0x14),
+            b'l' => NavigationAction::KeyPress(0x13),
+            b'j' => NavigationAction::Scroll(-line_step),
+            b'k' => NavigationAction::Scroll(line_step),
+            b'd' => NavigationAction::Scroll(-half_page),
+            b'u' => NavigationAction::Scroll(half_page),
+            b'g' => {
+                self.pending_g = true;
+                NavigationAction::Ignore
+            }
+            b'G' => NavigationAction::Scroll(-SCROLL_TO_EDGE_PX),
+            b'r' => NavigationAction::Refresh(),
+            b'H' => NavigationAction::GoBack(),
+            b'L' => NavigationAction::GoForward(),
+            b'n' => {
+                if self.find_query.is_some() {
+                    self.find_cursor = self.find_cursor.wrapping_add(1);
+                }
+                NavigationAction::Ignore
+            }
+            b'N' => {
+                if self.find_query.is_some() {
+                    self.find_cursor = self.find_cursor.wrapping_sub(1);
+                }
+                NavigationAction::Ignore
+            }
+            b'f' => {
+                self.mode = Mode::Hint;
+                self.hint_buf.clear();
+                self.hints.clear();
+                NavigationAction::Ignore
+            }
+            _ => NavigationAction::Ignore,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a built-in keyboard navigation layer modelled on
[Vimium](https://github.com/philc/vimium) so Carbonyl can be driven without a
mouse. The layer intercepts keys when no input field is focused; otherwise
keys pass through to the page as before.

## Bindings

| Mode   | Key             | Action                                   |
| ------ | --------------- | ---------------------------------------- |
| Normal | `h` `j` `k` `l` | Scroll left/down/up/right                |
| Normal | `d` `u`         | Half-page down/up                        |
| Normal | `gg` `G`        | Scroll to top / bottom                   |
| Normal | `H` `L`         | History back / forward                   |
| Normal | `r`             | Reload                                   |
| Normal | `/`             | Open in-page find prompt                 |
| Normal | `n` `N`         | Next / previous find match               |
| Normal | `f`             | Show clickable hint labels               |
| Normal | `i`             | Enter Insert mode (keys pass through)    |
| Any    | `Esc`           | Exit Find / Hint / Insert; clear hints   |

A status bar at the bottom of the viewport shows the current mode and any
in-progress query / hint prefix.

## Implementation notes

- New `src/ui/vimium.rs` owns the modal state (Normal / Insert / Find / Hint).
- `NavigationAction` is extended with `Scroll(px)`, `KeyPress(char)`, and
  `Click(col, row)` so the existing dispatch in `src/browser/bridge.rs` can
  drive wheel events, synthesised arrow keys, and synthetic clicks without
  touching the C++ bridge.
- Find and link-hint overlays live in `src/output/renderer.rs`. Cells touched
  by the overlay are snapshotted before mutation and restored on the next
  frame so toggling modes does not leave stale highlights.
- Link candidates are detected from the rendered cell buffer (the DOM is not
  exposed to Rust): same-colour contiguous runs are merged across single
  whitespace, then included if they are short (<= 30 cells) or visually
  distinct from the dominant text colour. This catches both typical blue
  anchors and link-coloured nav items that share the body colour.
- Synthetic clicks post `mouse_down` on the browser thread and schedule
  `mouse_up` ~80 ms later from a side thread, so blink registers the pair as
  a real click without stalling the browser main thread.

## Limitations

- Find searches only the currently visible viewport, ASCII case-insensitive.
- Hint detection is heuristic, so some labelled spans turn out to be plain
  text (clicking them is a no-op). The status bar shows the total hint count.

## Test plan

- [ ] `h` / `j` / `k` / `l` scroll the page
- [ ] `d` / `u` / `gg` / `G` scroll by half pages and to the extremes
- [ ] `H` / `L` / `r` navigate history and reload
- [ ] `/foo<enter>` highlights matches and `n` / `N` cycle them
- [ ] `f` then a label letter navigates a link on a typical page
- [ ] `i` enters insert mode and `Esc` exits
- [ ] All of the above behave the same inside and outside tmux
